### PR TITLE
Enable webcam streaming for remote detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,10 @@ Powered by:
 - Mobile control panel
 
 Made with ❤️ for artists who work better with vibes.
+
+### Webcam Streaming
+
+Set the `AI_MODEL_URL` environment variable to the URL of your detection server.
+When running, the web interface will capture webcam frames and send them to this
+endpoint. The response should be JSON with a `drawing` flag used to control
+Spotify playback.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ onnxruntime
 opencv-python
 numpy
 python-dotenv
+requests

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,6 +81,9 @@
 
   <h1>LiveArt Interface</h1>
 
+  <video id="webcam" width="320" height="240" autoplay muted style="display:none"></video>
+  <canvas id="frameCanvas" width="320" height="240" style="display:none"></canvas>
+
   <div class="tabs">
     <div class="tab active" onclick="switchTab('music')">Spotify Panel</div>
     <div class="tab" onclick="switchTab('search')">Reference Search</div>
@@ -158,6 +161,26 @@
     }
 
     setInterval(updateNowPlaying, 5000);
+
+    // === Webcam streaming ===
+    const video = document.getElementById('webcam');
+    const canvas = document.getElementById('frameCanvas');
+    const ctx = canvas.getContext('2d');
+
+    navigator.mediaDevices.getUserMedia({ video: true }).then(stream => {
+      video.srcObject = stream;
+    });
+
+    function sendFrame() {
+      ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+      canvas.toBlob(blob => {
+        const fd = new FormData();
+        fd.append('frame', blob, 'frame.jpg');
+        fetch('/frame', { method: 'POST', body: fd });
+      }, 'image/jpeg');
+    }
+
+    setInterval(sendFrame, 500);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- stream webcam frames from the browser
- forward frames to remote AI server from Flask backend
- support optional remote detection in `detector.py`
- document new `AI_MODEL_URL` environment variable
- add `requests` to requirements

## Testing
- `python -m py_compile app.py detector.py spotify.py`
- `pip install -q -r requirements.txt`
- `python app.py` *(fails: Spotify credentials missing)*

------
https://chatgpt.com/codex/tasks/task_e_6868d4a5d060832cb47eef4e6d944457